### PR TITLE
fix(5.4-6.0): fix mapping of SO_Objekt.rechtscharakter

### DIFF
--- a/Versionsmigration/5.4-6.0/xplangml-migration-54-60b.halex.alignment.xml
+++ b/Versionsmigration/5.4-6.0/xplangml-migration-54-60b.halex.alignment.xml
@@ -1173,61 +1173,6 @@
         </complexParameter>
         <parameter value="null" name="notClassifiedAction"/>
     </cell>
-    <cell relation="eu.esdihumboldt.hale.align.classification" id="Ca42e84a4-49c3-4d7c-90b3-09072697f697" priority="normal">
-        <source>
-            <property>
-                <type name="SO_ObjektType" ns="http://www.xplanung.de/xplangml/5/4"/>
-                <child name="rechtscharakter" ns="http://www.xplanung.de/xplangml/5/4"/>
-            </property>
-        </source>
-        <target>
-            <property>
-                <type name="BP_ObjektType" ns="http://www.xplanung.de/xplangml/6/0"/>
-                <child name="rechtscharakter" ns="http://www.xplanung.de/xplangml/6/0"/>
-            </property>
-        </target>
-        <complexParameter name="lookupTable">
-            <lookup-table xmlns:ns2="http://www.esdi-humboldt.eu/hale/alignment" xmlns="">
-                <entry>
-                    <key value="1000"/>
-                    <value value="1000"/>
-                </entry>
-                <entry>
-                    <key value="1500"/>
-                    <value value="3000"/>
-                </entry>
-                <entry>
-                    <key value="1800"/>
-                    <value value="5300"/>
-                </entry>
-                <entry>
-                    <key value="2000"/>
-                    <value value="2000"/>
-                </entry>
-                <entry>
-                    <key value="3000"/>
-                    <value value="6000"/>
-                </entry>
-                <entry>
-                    <key value="4000"/>
-                    <value value="8000"/>
-                </entry>
-                <entry>
-                    <key value="5000"/>
-                    <value value="7000"/>
-                </entry>
-                <entry>
-                    <key value="9998"/>
-                    <value value="9998"/>
-                </entry>
-                <entry>
-                    <key value="9999"/>
-                    <value value="9999"/>
-                </entry>
-            </lookup-table>
-        </complexParameter>
-        <parameter value="null" name="notClassifiedAction"/>
-    </cell>
     <cell relation="eu.esdihumboldt.hale.align.retype" id="Cdee671c3-3c43-40ad-80ac-c3de45ce59f0" priority="normal">
         <source>
             <class>
@@ -5738,6 +5683,61 @@ if (typ) {&#xD;
             <core:name xmlns:core="http://www.esdi-humboldt.eu/hale/core" namespace="http://www.xplanung.de/xplangml/5/4">rechtscharakter</core:name>
         </complexParameter>
         <parameter value="true" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.classification" id="Ca42e84a4-49c3-4d7c-90b3-09072697f697" priority="normal">
+        <source>
+            <property>
+                <type name="SO_ObjektType" ns="http://www.xplanung.de/xplangml/5/4"/>
+                <child name="rechtscharakter" ns="http://www.xplanung.de/xplangml/5/4"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="SO_ObjektType" ns="http://www.xplanung.de/xplangml/6/0"/>
+                <child name="rechtscharakter" ns="http://www.xplanung.de/xplangml/6/0"/>
+            </property>
+        </target>
+        <complexParameter name="lookupTable">
+            <lookup-table xmlns:ns2="http://www.esdi-humboldt.eu/hale/alignment" xmlns="">
+                <entry>
+                    <key value="1800"/>
+                    <value value="5300"/>
+                </entry>
+                <entry>
+                    <key value="1500"/>
+                    <value value="3000"/>
+                </entry>
+                <entry>
+                    <key value="5000"/>
+                    <value value="7000"/>
+                </entry>
+                <entry>
+                    <key value="4000"/>
+                    <value value="8000"/>
+                </entry>
+                <entry>
+                    <key value="9998"/>
+                    <value value="9998"/>
+                </entry>
+                <entry>
+                    <key value="1000"/>
+                    <value value="1000"/>
+                </entry>
+                <entry>
+                    <key value="2000"/>
+                    <value value="2000"/>
+                </entry>
+                <entry>
+                    <key value="3000"/>
+                    <value value="6000"/>
+                </entry>
+                <entry>
+                    <key value="9999"/>
+                    <value value="9999"/>
+                </entry>
+            </lookup-table>
+        </complexParameter>
+        <parameter value="null" name="notClassifiedAction"/>
     </cell>
     <cell relation="eu.esdihumboldt.hale.align.retype" id="C9a100022-dbaf-4f09-a8d2-3f81bb62d53a" priority="normal">
         <source>


### PR DESCRIPTION
Previously, the property `rechtscharakter` of the source type `SO_Objekt` was mapped to the target type `BP_Objekt`. This is changed here so that it maps to `SO_Objekt` on the target side.

SVC-1398