### PR TITLE
fix: make sure that reference is only created when existing

### DIFF
--- a/Versionsmigration/5.4-6.0/xplangml-migration-54-60b.halex
+++ b/Versionsmigration/5.4-6.0/xplangml-migration-54-60b.halex
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="5.0.1.release">
+<hale-project version="5.1.0.SNAPSHOT">
     <name>Migration XPlanGML 5.4 zu 6.0</name>
     <author>Thorsten Reitz (im Auftrag der XLeitstelle/von Dataport)</author>
     <created>2022-07-13T10:19:12.076+02:00</created>
-    <modified>2023-08-22T14:26:52.487+02:00</modified>
+    <modified>2023-08-30T16:14:31.991+02:00</modified>
     <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/Versionsmigration/5.4-6.0/xplangml-migration-54-60b.halex.alignment.xml
+++ b/Versionsmigration/5.4-6.0/xplangml-migration-54-60b.halex.alignment.xml
@@ -12164,21 +12164,35 @@ if (refLegende){&#13;
         <parameter value="true" name="ignoreNamespaces"/>
         <parameter value="true" name="structuralRename"/>
     </cell>
-    <cell relation="eu.esdihumboldt.hale.align.formattedstring" id="C136c3e16-8af3-4c3d-9ce6-89c660b0af55" priority="normal">
+    <cell relation="eu.esdihumboldt.cst.functions.groovy" id="C136c3e16-8af3-4c3d-9ce6-89c660b0af55" priority="normal">
         <source name="var">
             <property>
                 <type name="XP_RasterdarstellungType" ns="http://www.xplanung.de/xplangml/5/4"/>
                 <child name="id" ns="http://www.opengis.net/gml/3.2"/>
             </property>
         </source>
-        <target>
+        <source name="var">
+            <property>
+                <type name="XP_RasterdarstellungType" ns="http://www.xplanung.de/xplangml/5/4"/>
+                <child name="refText" ns="http://www.xplanung.de/xplangml/5/4"/>
+            </property>
+        </source>
+        <target name="result">
             <property>
                 <type name="XP_PlanType" ns="http://www.xplanung.de/xplangml/6/0"/>
                 <child name="texte" ns="http://www.xplanung.de/xplangml/6/0"/>
-                <child name="href" ns="http://www.w3.org/1999/xlink"/>
             </property>
         </target>
-        <parameter value="#{id}" name="pattern"/>
+        <complexParameter name="script">
+            <core:text xmlns:core="http://www.esdi-humboldt.eu/hale/core" xml:space="preserve">
+if (refText) {&#13;
+	target {&#13;
+		href ("#{$id}")&#13;
+	}&#13;
+}
+</core:text>
+        </complexParameter>
+        <parameter value="true" name="variablesAsInstances"/>
     </cell>
     <cell relation="eu.esdihumboldt.hale.align.rename" id="Cbb250a76-f578-4fad-8714-747b252a32b1" priority="normal">
         <source>


### PR DESCRIPTION
In case the attribute refText is populated, an XP_Rasterdarstellung object is resulting in an XP_TextAbschnitt object. The reference from XP_Plan to this XP_TextAbschnitt object had been created in any case (independent from if the refText attribute is populated or not). This is now fixed so that the reference is only created if there is also a respective XP_TextAbschnitt.

SVC-1179