### PR TITLE
fix(5.4-6.0): delete mapping of BP/FP_Plan.externeReferenz

### DIFF
--- a/Versionsmigration/5.4-6.0/xplangml-migration-54-60b.halex.alignment.xml
+++ b/Versionsmigration/5.4-6.0/xplangml-migration-54-60b.halex.alignment.xml
@@ -2439,22 +2439,6 @@ else {&#13;
         <parameter value="false" name="ignoreNamespaces"/>
         <parameter value="false" name="structuralRename"/>
     </cell>
-    <cell relation="eu.esdihumboldt.hale.align.rename" id="Ce4eeed9b-1e73-4b8b-8ff8-247999023f39" priority="normal">
-        <source>
-            <property>
-                <type name="BP_PlanType" ns="http://www.xplanung.de/xplangml/5/4"/>
-                <child name="externeReferenz" ns="http://www.xplanung.de/xplangml/5/4"/>
-            </property>
-        </source>
-        <target>
-            <property>
-                <type name="BP_PlanType" ns="http://www.xplanung.de/xplangml/6/0"/>
-                <child name="externeReferenz" ns="http://www.xplanung.de/xplangml/6/0"/>
-            </property>
-        </target>
-        <parameter value="true" name="ignoreNamespaces"/>
-        <parameter value="true" name="structuralRename"/>
-    </cell>
     <cell relation="eu.esdihumboldt.hale.align.rename" id="Cafdfe369-2ac6-4ea1-bbc9-ba185e6637e6" priority="normal">
         <source>
             <property>
@@ -5423,22 +5407,6 @@ else {&#13;
         </target>
         <parameter value="false" name="ignoreNamespaces"/>
         <parameter value="false" name="structuralRename"/>
-    </cell>
-    <cell relation="eu.esdihumboldt.hale.align.rename" id="C32a80ee2-c7a5-4c05-8092-b172692901dd" priority="normal">
-        <source>
-            <property>
-                <type name="FP_PlanType" ns="http://www.xplanung.de/xplangml/5/4"/>
-                <child name="externeReferenz" ns="http://www.xplanung.de/xplangml/5/4"/>
-            </property>
-        </source>
-        <target>
-            <property>
-                <type name="FP_PlanType" ns="http://www.xplanung.de/xplangml/6/0"/>
-                <child name="externeReferenz" ns="http://www.xplanung.de/xplangml/6/0"/>
-            </property>
-        </target>
-        <parameter value="true" name="ignoreNamespaces"/>
-        <parameter value="true" name="structuralRename"/>
     </cell>
     <cell relation="eu.esdihumboldt.hale.align.rename" id="C3596ad8b-90d0-4785-a081-5ebe3faea9a4" priority="normal">
         <source>


### PR DESCRIPTION
Delete rename from BP/FP_Plan.externeReferenz to BP/FP_Plan.externeReferenz because it is a duplicate. The correct mapping is done via the existing Inline transformation from XP_Plan.externeReferenz.SpezExterneReferenz to XP_Plan.externeReferenz.SpezExterneReferenz.

SVC-1179